### PR TITLE
Update the API Index Link to The Camping Book

### DIFF
--- a/api/index.html
+++ b/api/index.html
@@ -36,7 +36,7 @@
   			  <p>
 If you&#8217;re new to <a href="#class-Camping">Camping</a>, you
 should probably start by reading the first chapters of <a
-href="file:book/01_introduction.html#toc">The Camping Book</a>.
+href="book/01_introduction.html#toc">The Camping Book</a>.
 </p>
 <p>
 Okay. So, the important thing to remember is that <tt><a


### PR DESCRIPTION
In [the API documentation](http://camping.io/api/), there is a link to The Camping Book in the first paragraph. It currently links to `file:///book/01_introduction.html#toc`.
