### PR TITLE
add a button to the bottom right corner to expand all definitions

### DIFF
--- a/api/index.html
+++ b/api/index.html
@@ -20,6 +20,7 @@
   <div id="fullpage">
     <div class="page_shade">
     	<div class="page ref">
+        <button href="" id="expand_all">Expand All</button>
     	  <p class="header">Thu Aug 19 16:07:43 +0200 2010</p>
     	  <h1>Camping, the Reference</h1>
     	

--- a/api/index.html
+++ b/api/index.html
@@ -20,7 +20,7 @@
   <div id="fullpage">
     <div class="page_shade">
     	<div class="page ref">
-        <button href="" id="expand_all">Expand All</button>
+        <button id="expand_all">Expand All</button>
     	  <p class="header">Thu Aug 19 16:07:43 +0200 2010</p>
     	  <h1>Camping, the Reference</h1>
     	

--- a/api/js/camping.js
+++ b/api/js/camping.js
@@ -5,7 +5,7 @@ $(function() {
       var base = $(name);
       return base.parent().add(base.next());
     }
-    
+
     // #class-something -> $(the section below)
     function s(name) {
       return $(name).next();
@@ -23,14 +23,14 @@ $(function() {
     }
     return false;
   });
-  
+
   if ($('.ref')[0]) {
-    
-    $('.mod').hide(); 
+
+    $('.mod').hide();
     $('.method').hide();
-    
+
     var hash = window.location.hash.replace(/--$/, '');
-    
+
     if (hash.substring(0, 2) == "#M") {
       // Show the method and the section
       m(hash).show();
@@ -41,12 +41,12 @@ $(function() {
       // Show the first section.
       s("h2:first").show();
     }
-    
+
     // We need to scroll!
     if (hash != window.location.hash) {
       window.location.hash = hash;
     }
-    
+
     $('a[href*="#class-"]').click(function() {
       var link = this.href;
       var id = link.substring(link.indexOf("#"));
@@ -60,7 +60,7 @@ $(function() {
         s(id).show();
       }
     });
-    
+
     $('a[href*="#M"]').click(function() {
       var link = this.href;
       var id = link.substring(link.indexOf("#"));
@@ -74,7 +74,12 @@ $(function() {
         m(id).show();
       }
     });
-    
   }
-  
+
+  // Expand all of the definitions
+  $('#expand_all').click(function(){
+    $('.mod,.method').show();
+    console.log("hello");
+    $(this).hide();
+  });
 });

--- a/api/js/camping.js
+++ b/api/js/camping.js
@@ -79,7 +79,6 @@ $(function() {
   // Expand all of the definitions
   $('#expand_all').click(function(){
     $('.mod,.method').show();
-    console.log("hello");
     $(this).hide();
   });
 });

--- a/api/rdoc.css
+++ b/api/rdoc.css
@@ -115,3 +115,10 @@ pre.sourcecode { color: #DDDDDD; background-color: #775915; padding: 4px 8px; ma
 .cmt { color: #CCFFCC; font-style: italic }
 .str { color: #EECCCC; font-style: italic }
 .re  { color: #EECCCC; }
+
+#expand_all {
+  display: block;
+  position: fixed;
+  right: 20px;
+  bottom: 20px;
+}


### PR DESCRIPTION
Based upon [issue #67](https://github.com/camping/camping/issues/67) in the camping repo, I went ahead and created an Expand All button that hangs out in the lower right corner.

![Screen Shot 2013-02-01 at 2 42 14 PM](https://f.cloud.github.com/assets/928367/119494/a928e172-6ca7-11e2-96c1-9254f22b9d21.png)

It is not pretty yet, but it works. When it is clicked, it hides itself.

The diffs for the lines in the JS file are from me deleting whitespace.
